### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ $ open -a TextEdit ~/Library/Mobile\ Documents/com~apple~mail/Data/V3/MailData/S
 **NB**: Images won't appear in the signature preview, but will work fine when you compose a message.
 
 
-####Solution 2
+#### Solution 2
 You can also open the HTML files in `/dist` in a browser, CMD + A, CMD + C and then paste into the signature box. This won't copy the `<html>` part or the `<style>` part that includes media queries. Follow the guide if you want it.
 
 

--- a/i18n/ko-KR.md
+++ b/i18n/ko-KR.md
@@ -137,6 +137,6 @@ start Signatures
 <br/>
 <a href="http:fadeit.dk"><img src="http://fadeit.dk/src/assets/img/brand/fadeit_logo_full.svg" alt="The fadeit logo" style="width:200px;"/></a><br/><br/>
 
-####About fadeit
+#### About fadeit
 We build awesome software, web and mobile applications.
 See more at [fadeit.dk](http://fadeit.dk)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
